### PR TITLE
解析結果の削除用エンドポイントを追加

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisResultsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisResultsController.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace App\Http\Controllers;
 
 use App\AnalysisResults;
+use App\Tweets;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
@@ -25,5 +25,13 @@ class AnalysisResultsController extends Controller
 
         $results['user_ranking'] = $tweet_users;
         return \Response::json($results);
+    }
+    public function delete($id)
+    {
+        $tweets_query = Tweets::query();
+        $tweets_query->where('analysis_result_id', '=', $id)->delete();
+
+        AnalysisResults::find($id)->delete();
+        return 204;
     }
 }

--- a/a6s-cloud/routes/api.php
+++ b/a6s-cloud/routes/api.php
@@ -20,3 +20,4 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::get('v1/AnalysisResultLists', 'AnalysisResultListsController@index');
 Route::post('v1/AnalysisRequests', 'AnalysisRequestsController@create');
 Route::get('v1/AnalysisResults/{id}', 'AnalysisResultsController@show');
+Route::delete('v1/AnalysisResults/{id}', 'AnalysisResultsController@delete');


### PR DESCRIPTION
# 対応内容
#154 の内容を修正しました。

# 確認方法
DELETE メソッドで削除対象の解析依頼のリクエストを飛ばしてください。
例) curl の場合
```
curl -X "DELETE" http://localhost/api/v1/AnalysisResults/1
```
そのあと、解析結果が削除されていることを確認願います。

# クローズするissue
close #154

# このタスクで発生したissue
なし

# その他
なし