### PR TITLE
アプリケーションエラーをslackへ通知する

### DIFF
--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -41,12 +41,13 @@ class AnalysisRequestsController extends Controller
             logger(print_r($e->getMessage(), true));
             logger(print_r($e->getTraceAsString(), true));
 
-            SlackFile::upload([
-                'filename' => 'wordCloudError.txt',
-                'content' => $e->getMessage().$e->getTraceAsString(),
-                'channels' => '#grouscope_applog',
-                'initial_comment' => 'WordCloudの処理でエラーがでたよー:sob:'
-            ]);
+            // 開発時に出力しないためにコメントアウト
+            // SlackFile::upload([
+            //     'filename' => 'wordCloudError.txt',
+            //     'content' => $e->getMessage().$e->getTraceAsString(),
+            //     'channels' => '#grouscope_applog',
+            //     'initial_comment' => 'WordCloudの処理でエラーがでたよー:sob:'
+            // ]);
             return response($id, 500);
         }
 

--- a/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
+++ b/a6s-cloud/app/Http/Controllers/AnalysisRequestsController.php
@@ -8,6 +8,7 @@ use AnalysisRequestService;
 use TwitterClientService;
 use App\Rules\NonDuplicateAnalysisRequest;
 use App\Rules\NGAnalysisWord;
+use SlackFile;
 
 class AnalysisRequestsController extends Controller
 {
@@ -40,6 +41,12 @@ class AnalysisRequestsController extends Controller
             logger(print_r($e->getMessage(), true));
             logger(print_r($e->getTraceAsString(), true));
 
+            SlackFile::upload([
+                'filename' => 'wordCloudError.txt',
+                'content' => $e->getMessage().$e->getTraceAsString(),
+                'channels' => '#grouscope_applog',
+                'initial_comment' => 'WordCloudの処理でエラーがでたよー:sob:'
+            ]);
             return response($id, 500);
         }
 

--- a/a6s-cloud/composer.json
+++ b/a6s-cloud/composer.json
@@ -15,7 +15,8 @@
         "grohiro/laravel-camelcase-json": "~1.0",
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "5.8.*",
-        "laravel/tinker": "^1.0"
+        "laravel/tinker": "^1.0",
+        "vluzrmos/slack-api": "^0.4.8"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.0",

--- a/a6s-cloud/composer.lock
+++ b/a6s-cloud/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff94bdd67ac8e3dfeb49762934b78d16",
+    "content-hash": "e810601f5272863ef8df08427a9e577a",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -3211,6 +3211,53 @@
                 "environment"
             ],
             "time": "2019-03-06T09:39:45+00:00"
+        },
+        {
+            "name": "vluzrmos/slack-api",
+            "version": "v0.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vluzrmos/laravel-slack-api.git",
+                "reference": "8213d8db19be6546fac0db5256aad1cfdfac7fae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vluzrmos/laravel-slack-api/zipball/8213d8db19be6546fac0db5256aad1cfdfac7fae",
+                "reference": "8213d8db19be6546fac0db5256aad1cfdfac7fae",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~5.3|~6.0",
+                "illuminate/cache": "~5.0",
+                "illuminate/support": "~5.0",
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Vluzrmos\\": "src/Vluzrmos/"
+                },
+                "files": [
+                    "src/Vluzrmos/SlackApi/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "DBAD"
+            ],
+            "authors": [
+                {
+                    "name": "Vagner do Carmo",
+                    "email": "vluzrmos@gmail.com"
+                }
+            ],
+            "description": "Wrapper for Slack.com WEB API.",
+            "keywords": [
+                "laravel",
+                "lumen",
+                "slack"
+            ],
+            "time": "2016-10-22T16:34:17+00:00"
         }
     ],
     "packages-dev": [

--- a/a6s-cloud/config/app.php
+++ b/a6s-cloud/config/app.php
@@ -175,6 +175,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         Grohiro\LaravelCamelCaseJson\CamelCaseJsonResponseServiceProvider::class,
+        Vluzrmos\SlackApi\SlackApiServiceProvider::class,
     ],
 
     /*
@@ -228,6 +229,18 @@ return [
         'AnalysisRequestService' => App\Facades\AnalysisRequestService::class,
         'TwitterClientService' => App\Facades\TwitterClientService::class,
         'ScrapingService' => App\Facades\ScrapingService::class,
+        'SlackApi' => Vluzrmos\SlackApi\Facades\SlackApi::class,
+        'SlackChannel' => Vluzrmos\SlackApi\Facades\SlackChannel::class,
+        'SlackChat' => Vluzrmos\SlackApi\Facades\SlackChat::class,
+        'SlackGroup' => Vluzrmos\SlackApi\Facades\SlackGroup::class,
+        'SlackFile' => Vluzrmos\SlackApi\Facades\SlackFile::class,
+        'SlackSearch' => Vluzrmos\SlackApi\Facades\SlackSearch::class,
+        'SlackInstantMessage' => Vluzrmos\SlackApi\Facades\SlackInstantMessage::class,
+        'SlackUser' => Vluzrmos\SlackApi\Facades\SlackUser::class,
+        'SlackStar' => Vluzrmos\SlackApi\Facades\SlackStar::class,
+        'SlackUserAdmin' => Vluzrmos\SlackApi\Facades\SlackUserAdmin::class,
+        'SlackRealTimeMessage' => Vluzrmos\SlackApi\Facades\SlackRealTimeMessage::class,
+        'SlackTeam' => Vluzrmos\SlackApi\Facades\SlackTeam::class,
     ],
 
 ];

--- a/a6s-cloud/config/services.php
+++ b/a6s-cloud/config/services.php
@@ -44,4 +44,7 @@ return [
         ],
     ],
 
+    'slack' => [
+        'token' => env('SLACK_TOKEN')
+    ],
 ];


### PR DESCRIPTION
# 対応内容
#139 の内容を修正しました。

# 確認方法
コードとslackの`#grouscope_applog`で通知内容の雰囲気を確認できます。

もし動作確認する場合は下記の手順で確認できます。
1. composer install
  laravel-slack-apiをインストール
2. `.env` にtokenを記載
  ```
SLACK_TOKEN="slackで別途共有します"
  ```
3. AnalysisRequestsControllerの44行目周辺のコメントを外す
```
// 開発時に出力しないためにコメントアウト
SlackFile::upload([
     'filename' => 'wordCloudError.txt',
     'content' => $e->getMessage().$e->getTraceAsString(),
     'channels' => '#grouscope_applog',
      'initial_comment' => 'WordCloudの処理でエラーがでたよー:sob:'
  ]);
```
4. AnalysisRequestServiceのrunWordCloudを下記に変更
  python4にすることで強制的にエラーにする
```
$process = new Process([
            'python4',
            base_path() . '/../a6s-cloud-batch/src/createWordCloud.py',
            $this->localStoragePath . $this->getTweetsFileForWordcloud(),
            base_path() . '/../RictyDiminished/RictyDiminished-Bold.ttf',
            $this->publicStoragePath . $this->getImageFileForWordcloud()
        ]);
```
5. 解析実行
  こんな感じになるはずです
<img width="757" alt="スクリーンショット 2019-05-26 12 58 11" src="https://user-images.githubusercontent.com/34429882/58377492-0de26c80-7fbd-11e9-83fe-7a5e73d7bff1.png">


# クローズするissue
close #139 

# このタスクで発生したissue
とくになし

# その他
ライブラリは[laravel-slack-api](https://github.com/vluzrmos/laravel-slack-api)を使用してます。使い方もREAD.MEに載っています！！

# 参考URL
[Laravel_Slack通知で実践した_リアルタイムエラー共有開発](https://speakerdeck.com/miyakeylab/laravel-slacktong-zhi-teshi-jian-sita-riarutaimueragong-you-kai-fa)
[laravel-slack-api](https://github.com/vluzrmos/laravel-slack-api)