### PR TITLE
nginx イメージを作成

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,6 @@
 FROM nginx:1.17
 MAINTAINER Tsutomu Nakamura<tsuna.0x00@gmail.com>
 
+RUN apt-get update && \
+        apt-get -y upgrade
 COPY default.conf /etc/nginx/conf.d/default.conf

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,14 +1,4 @@
 FROM nginx:1.17
 MAINTAINER Tsutomu Nakamura<tsuna.0x00@gmail.com>
 
-COPY grouscope.conf 
-
-RUN apt-get update && \
-        apt-get upgrade && \
-        apt-get install -y --no-install-recommends libfreetype6-dev libjpeg-dev libpng-dev libwebp-dev libgmp-dev
-        #docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/inclue/ --with-webp-dir=/usr/include/
-
-COPY default-site.conf /etc/nginx/conf.d/default.conf
-
-# このCMD のコマンドは /usr/local/bin/docker-php-entrypoint に渡される
-
+COPY default.conf /etc/nginx/conf.d/default.conf

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx:1.17
+MAINTAINER Tsutomu Nakamura<tsuna.0x00@gmail.com>
+
+COPY grouscope.conf 
+
+RUN apt-get update && \
+        apt-get upgrade && \
+        apt-get install -y --no-install-recommends libfreetype6-dev libjpeg-dev libpng-dev libwebp-dev libgmp-dev
+        #docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/inclue/ --with-webp-dir=/usr/include/
+
+COPY default-site.conf /etc/nginx/conf.d/default.conf
+
+# このCMD のコマンドは /usr/local/bin/docker-php-entrypoint に渡される
+

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name  default_server;
+    root   /var/www/html/a6s_cloud/public;
+    index index.php index.html;
+
+    client_max_body_size 10m;
+
+    location / {
+        add_header X-Request-Id $request_id always;
+        try_files $uri $uri/ /index.php?$query_string;
+
+        location ~ ^/index.php {
+            internal;
+            include fastcgi_params;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass php-fpm:9000;
+            fastcgi_param HTTP_X_Request_Id $request_id;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_read_timeout 300s;
+        }
+
+        location ~ \.php$ {
+             return 404;
+         }
+    }
+}

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -14,7 +14,7 @@ server {
             internal;
             include fastcgi_params;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass php-fpm:9000;
+            fastcgi_pass localhost:9000;
             fastcgi_param HTTP_X_Request_Id $request_id;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
# 対応内容
#163 の内容に対応しました。

# 確認方法
// イメージは既にDocker Hub 上にアップされた状態になっています。
ターミナル1 を開き、以下のコマンドを実行します。laradock 等の80 番ポートを使っているアプリがあれば、それは落としておいてください。

```
$ docker run --rm -p 80:80 -ti a6scloud/grouscope-nginx:testing
// testing タグ付きで実行します。コマンド実行後、待受の状態になります
```

ターミナル2 を開き、以下のようにcurl コマンドを実行します。

```
curl http://localhost
```

ターミナル1 にエラーログが出ること。
```
2019/07/15 09:06:34 [error] 6#6: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 172.17.0.1, server: default_server, request: "GET / HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "localhost:1008
0"
2019/07/15 09:06:34 [warn] 6#6: *1 upstream server temporarily disabled while connecting to upstream, client: 172.17.0.1, server: default_server, request: "GET / HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "localhost:10080"
2019/07/15 09:06:34 [error] 6#6: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 172.17.0.1, server: default_server, request: "GET / HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "localhost:1008
0"
2019/07/15 09:06:34 [warn] 6#6: *1 upstream server temporarily disabled while connecting to upstream, client: 172.17.0.1, server: default_server, request: "GET / HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "localhost:10080"
172.17.0.1 - - [15/Jul/2019:09:06:34 +0000] "GET / HTTP/1.1" 502 157 "-" "curl/7.65.1" "-"
```

ターミナル2 に`502 Bad Gateway` エラーが表示されること。

```
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.17.1</center>
</body>
</html>
// laravel コンテナができたら正常レスポンスが取れるようになります。
```

# クローズするissue
close #163 

# このタスクで発生したissue
なし

# その他
このプルリクがmaster ブランチにマージされると、自動ビルドにより10 分後くらいにはタグ無し(=latest タグ)でもnginx コンテナが起動できるようになっている想定です。

```
docker run --rm -p 80:80 -ti a6scloud/grouscope-nginx
```