### PR TITLE
docker-compose.yml のバージョンを3 に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3.7'
+version: '3'
 
 networks:
   a6s:
-    name: a6s
     driver: bridge
 
 services:


### PR DESCRIPTION
# 対応内容
#178 の内容を修正しました。

# 確認方法
今までどおりコマンドを実行してコンテナが起動することを確認してください。
```
docker-compose up
// Laravel コンテナの"NOTICE: ready to handle connections" が表示されること
```

# クローズするissue
close #178

# このタスクで発生したissue
なし

# その他
Ubuntu 18.04 LTS の公式リポジトリからインストールされるdocker-compose でも動くように、変更しました。
緊急でもないので、お時間ある時にマージお願いします🙇‍♂️